### PR TITLE
Fixes integer precision implicit cast warning on 64-bit platforms

### DIFF
--- a/include/xmlwrapp/document.h
+++ b/include/xmlwrapp/document.h
@@ -84,7 +84,7 @@ class XMLWRAPP_API document
 {
 public:
     /// size type
-    typedef std::size_t size_type;
+    typedef int size_type;
 
     /**
         Create a new XML document with the default settings. The new document

--- a/include/xmlwrapp/event_parser.h
+++ b/include/xmlwrapp/event_parser.h
@@ -69,7 +69,7 @@ public:
     /// a type for holding XML node attributes
     typedef std::map<std::string, std::string> attrs_type;
     /// size type
-    typedef std::size_t size_type;
+    typedef int size_type;
 
     /// Default constructor.
     event_parser();

--- a/include/xmlwrapp/tree_parser.h
+++ b/include/xmlwrapp/tree_parser.h
@@ -73,7 +73,7 @@ struct tree_impl;
 class XMLWRAPP_API tree_parser
 {
 public:
-    typedef std::size_t size_type;
+    typedef int size_type;
     /**
         xml::tree_parser class constructor. Given the name of a file, this
         constructor will parse that file.

--- a/src/libxml/node.cxx
+++ b/src/libxml/node.cxx
@@ -320,7 +320,7 @@ node::node(cdata cdata_info)
 {
     std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
-    if ( (pimpl_->xmlnode_ = xmlNewCDataBlock(0, reinterpret_cast<const xmlChar*>(cdata_info.t), std::strlen(cdata_info.t))) == 0)
+    if ( (pimpl_->xmlnode_ = xmlNewCDataBlock(0, reinterpret_cast<const xmlChar*>(cdata_info.t), (int)std::strlen(cdata_info.t))) == 0)
     {
         throw std::bad_alloc();
     }


### PR DESCRIPTION
On 64-bit platforms several `size_type` `typedef`s are declared as `size_t`, however, on libxml2 sizes are declared as `int` causing a implicit cast warning on compilation. On many 32-bit platforms `size_t` matches `int` declaration and thus the warning is not visible.
