### PR TITLE
Add --disable-tests configure option to skip building tests.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
+if WITH_TESTS
+maybe_tests = tests
+endif
 
-SUBDIRS = include src examples tests docs
+SUBDIRS = include src examples $(maybe_tests) docs
 
 pkgconfigdir=$(libdir)/pkgconfig
 

--- a/README
+++ b/README
@@ -23,6 +23,10 @@ In order to build xmlwrapp, you need libxml2 version 2.4.28 or newer. When
 building with XSLT support, libxslt 1.1.6 or newer is required. Both libraries
 are available from http://xmlsoft.org.
 
+Header-only Boost Pool library is also required for building xmlwrapp.
+
+To run tests, Boost.Iostreams and Boost.Test libraries are also needed.
+
 
 2. Building on Unix
 -------------------
@@ -35,6 +39,9 @@ usually as simple as running the following three commands:
   make install
 
 See the output of `./configure --help` for additional settings and options.
+
+Use `--disable-tests` option to skip running tests and avoid the need for
+installing Boost.Iostreams and Test libraries.
 
 
 3. Building on Windows

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,17 @@ AC_CANONICAL_HOST
 
 dnl === Command line options ===
 
+AC_ARG_ENABLE(tests,
+             [AC_HELP_STRING([--disable-tests],
+                             [don't build the tests])],
+             [case "x${enableval}" in
+                   x) build_tests=no ;;
+                xyes) build_tests=yes ;;
+                 xno) build_tests=no ;;
+                   *) AC_MSG_ERROR(bad value ${enableval} for --enable-tests) ;;
+             esac],
+             [build_tests=yes])
+
 AC_ARG_ENABLE(xslt,
              [AC_HELP_STRING([--disable-xslt],
                              [don't build libxsltwrapp library])],
@@ -88,8 +99,11 @@ fi
 AC_HEADER_ASSERT
 
 BOOST_REQUIRE
-BOOST_IOSTREAMS
-BOOST_TEST
+
+if test "x$build_tests" = "xyes" ; then
+    BOOST_IOSTREAMS
+    BOOST_TEST
+fi
 
 BOOST_FIND_HEADER([boost/pool/singleton_pool.hpp],
                   [],
@@ -132,6 +146,7 @@ if test "x$build_xslt" = "xyes" ; then
 fi
 AC_SUBST(LEGACY_LINK_FLAGS)
 
+AM_CONDITIONAL(WITH_TESTS, [ test "x$build_tests" = "xyes" ])
 AM_CONDITIONAL(WITH_XSLT, [ test "x$build_xslt" = "xyes" ])
 
 AC_CONFIG_FILES([


### PR DESCRIPTION
This allows to avoid installing Boost.Iostreams and Boost.Test needing just
for the tests when building the library itself.

Also document these requirements.
