### PR TITLE
Allow disabling building the documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,12 @@
+if WITH_DOCS
+maybe_docs = docs
+endif
+
 if WITH_TESTS
 maybe_tests = tests
 endif
 
-SUBDIRS = include src examples $(maybe_tests) docs
+SUBDIRS = include src examples $(maybe_tests) $(maybe_docs)
 
 pkgconfigdir=$(libdir)/pkgconfig
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,17 @@ AC_CANONICAL_HOST
 
 dnl === Command line options ===
 
+AC_ARG_ENABLE(docs,
+             [AC_HELP_STRING([--disable-docs],
+                             [don't build the documentation (requires Doxygen)])],
+             [case "x${enableval}" in
+                   x) build_docs=no ;;
+                xyes) build_docs=yes ;;
+                 xno) build_docs=no ;;
+                   *) AC_MSG_ERROR(bad value ${enableval} for --enable-docs) ;;
+             esac],
+             [build_docs=yes])
+
 AC_ARG_ENABLE(tests,
              [AC_HELP_STRING([--disable-tests],
                              [don't build the tests])],
@@ -146,6 +157,7 @@ if test "x$build_xslt" = "xyes" ; then
 fi
 AC_SUBST(LEGACY_LINK_FLAGS)
 
+AM_CONDITIONAL(WITH_DOCS, [ test "x$build_docs" = "xyes" ])
 AM_CONDITIONAL(WITH_TESTS, [ test "x$build_tests" = "xyes" ])
 AM_CONDITIONAL(WITH_XSLT, [ test "x$build_xslt" = "xyes" ])
 


### PR DESCRIPTION
Add --disable-docs configure command line option similar to the existing
--disable-tests which can be used to avoid building the documentation which is
especially useful if Doxygen is not available.