### PR TITLE
Bare minimum for building in C++11 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ compiler:
   - gcc
   - clang
 
+env:
+  - CONFIGURE_OPTS="CXXFLAGS=-std=c++11"
+  - CONFIGURE_OPTS=""
+
 before_install:
   - sudo apt-get update -qq
 
@@ -12,7 +16,7 @@ install:
   - sudo apt-get install -qq libxml2-dev libxslt1-dev libboost-dev libboost-iostreams-dev libboost-test-dev
 
 script:
-  - ./bootstrap && ./configure && make && make check
+  - ./bootstrap && ./configure $(CONFIGURE_OPTS) && make && make check
 
 git:
   submodules: false

--- a/src/libxml/cpp11.h
+++ b/src/libxml/cpp11.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Vadim Zeitlin (vz-xmlwrapp@zeitlins.org)
+ * All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Author nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+    @file
+
+    This file attempts to hide the differences between C++03 and C++11.
+ */
+
+#ifndef _xsltwrapp_cpp11_h_
+#define _xsltwrapp_cpp11_h_
+
+#include <memory>
+
+// This symbol can be predefined to prevent the use of C++11 features even if
+// they are deemed to be available.
+#ifndef XMLWRAPP_NO_CPP11
+
+// This symbol, on the contrary, can be predefined to force the use of C++11
+// features even if they're not automatically detected.
+#ifndef XMLWRAPP_CPP11
+
+// We consider any compiler defining __cplusplus appropriately to be a C++11
+// compiler and make a special exception for MSVS 2015 which doesn't define it
+// but is close enough to be considered one.
+#if __cplusplus >= 201103L || \
+    (defined(_MSC_VER) && _MSC_VER >= 1900)
+    #define XMLWRAPP_CPP11
+#endif
+
+#endif // XMLWRAPP_CPP11
+
+// Additionally, some compilers support some C++11 features even though they
+// don't have the full C++11 support, notably earlier versions of MSVS.
+#if defined(XMLWRAPP_CPP11) || \
+    (defined(_MSC_VER) && _MSC_VER >= 1600)
+    #define XMLWRAPP_CPP11_MEMORY
+#endif
+
+#endif // !XMLWRAPP_NO_CPP11
+
+
+// Define auto_ptr<> as either std::auto_ptr<> or std::unique_ptr<> to allow
+// compiling the code in both C++ dialects without getting the warnings about
+// auto_ptr<> being deprecated in C++11 code.
+//
+// Notice that our xml::impl::auto_ptr<> is more like scoped_ptr<>, but we
+// can't call it this as we don't have type aliases in C++03 and so we can only
+// bring std::auto_ptr<> in scope but not rename it to scoped_ptr<> there.
+namespace xml
+{
+
+namespace impl
+{
+
+#ifdef XMLWRAPP_CPP11_MEMORY
+    template <typename T>
+    using auto_ptr = std::unique_ptr<T>;
+#else // C++03
+    using std::auto_ptr;
+#endif // C++03/11
+
+} // namespace impl
+
+} // namespace xml
+
+#endif // _xsltwrapp_cpp11_h_

--- a/src/libxml/document.cxx
+++ b/src/libxml/document.cxx
@@ -38,6 +38,7 @@
 #include "xmlwrapp/tree_parser.h"
 
 #include "utility.h"
+#include "cpp11.h"
 #include "dtd_impl.h"
 #include "node_manip.h"
 
@@ -190,7 +191,7 @@ document::document(const char *root_name)
 
 document::document(const node& n)
 {
-    std::auto_ptr<doc_impl> ap(pimpl_ = new doc_impl);
+    xml::impl::auto_ptr<doc_impl> ap(pimpl_ = new doc_impl);
     pimpl_->set_root_node(n);
     ap.release();
 }

--- a/src/libxml/node.cxx
+++ b/src/libxml/node.cxx
@@ -36,6 +36,7 @@
 #include "xmlwrapp/nodes_view.h"
 #include "xmlwrapp/attributes.h"
 #include "xmlwrapp/errors.h"
+#include "cpp11.h"
 #include "utility.h"
 #include "ait_impl.h"
 #include "node_manip.h"
@@ -269,7 +270,7 @@ node::node(int)
 
 node::node()
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     pimpl_->xmlnode_ = xmlNewNode(0, reinterpret_cast<const xmlChar*>("blank"));
     if (!pimpl_->xmlnode_)
@@ -281,7 +282,7 @@ node::node()
 
 node::node (const char *name)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     pimpl_->xmlnode_ = xmlNewNode(0, reinterpret_cast<const xmlChar*>(name));
     if (!pimpl_->xmlnode_)
@@ -293,7 +294,7 @@ node::node (const char *name)
 
 node::node (const char *name, const char *content)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     pimpl_->xmlnode_ = xmlNewNode(0, reinterpret_cast<const xmlChar*>(name));
     if (!pimpl_->xmlnode_)
@@ -318,7 +319,7 @@ node::node (const char *name, const char *content)
 
 node::node(cdata cdata_info)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     if ( (pimpl_->xmlnode_ = xmlNewCDataBlock(0, reinterpret_cast<const xmlChar*>(cdata_info.t), std::strlen(cdata_info.t))) == 0)
     {
@@ -331,7 +332,7 @@ node::node(cdata cdata_info)
 
 node::node(comment comment_info)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     if ( (pimpl_->xmlnode_ =  xmlNewComment(reinterpret_cast<const xmlChar*>(comment_info.t))) == 0)
     {
@@ -344,7 +345,7 @@ node::node(comment comment_info)
 
 node::node(pi pi_info)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     if ( (pimpl_->xmlnode_ = xmlNewPI(reinterpret_cast<const xmlChar*>(pi_info.n), reinterpret_cast<const xmlChar*>(pi_info.c))) == 0)
     {
@@ -357,7 +358,7 @@ node::node(pi pi_info)
 
 node::node(text text_info)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     if ( (pimpl_->xmlnode_ =  xmlNewText(reinterpret_cast<const xmlChar*>(text_info.t))) == 0)
     {
@@ -370,7 +371,7 @@ node::node(text text_info)
 
 node::node(const node& other)
 {
-    std::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
+    xml::impl::auto_ptr<node_impl> ap(pimpl_ = new node_impl);
 
     pimpl_->xmlnode_ = xmlCopyNode(other.pimpl_->xmlnode_, 1);
     if (!pimpl_->xmlnode_)

--- a/src/libxml/tree_parser.cxx
+++ b/src/libxml/tree_parser.cxx
@@ -35,6 +35,7 @@
 #include "xmlwrapp/tree_parser.h"
 #include "xmlwrapp/document.h"
 #include "xmlwrapp/errors.h"
+#include "cpp11.h"
 #include "utility.h"
 #include "errors_impl.h"
 
@@ -145,7 +146,7 @@ tree_parser::tree_parser(const char *name, error_handler& on_error)
 
 void tree_parser::init(const char *name, error_handler *on_error)
 {
-    std::auto_ptr<tree_impl> ap(pimpl_ = new tree_impl);
+    xml::impl::auto_ptr<tree_impl> ap(pimpl_ = new tree_impl);
 
     pimpl_->okay_ = true;
     xmlDocPtr tmpdoc = xmlSAXParseFileWithData(&(pimpl_->sax_), name, 0, pimpl_);
@@ -204,7 +205,7 @@ tree_parser::tree_parser(const char *data, size_type size, error_handler& on_err
 
 void tree_parser::init(const char *data, size_type size, error_handler *on_error)
 {
-    std::auto_ptr<tree_impl> ap(pimpl_ = new tree_impl);
+    xml::impl::auto_ptr<tree_impl> ap(pimpl_ = new tree_impl);
     xmlParserCtxtPtr ctxt;
 
     if ( (ctxt = xmlCreateMemoryParserCtxt(data, size)) == 0)

--- a/src/libxslt/stylesheet.cxx
+++ b/src/libxslt/stylesheet.cxx
@@ -44,6 +44,7 @@
 #include "xmlwrapp/errors.h"
 
 #include "result.h"
+#include "../libxml/cpp11.h"
 #include "../libxml/utility.h"
 #include "../libxml/errors_impl.h"
 
@@ -202,7 +203,7 @@ xslt::stylesheet::stylesheet(xml::document doc, xml::error_handler& on_error)
 void xslt::stylesheet::init(xml::document& doc, xml::error_handler& on_error)
 {
     xmlDocPtr xmldoc = static_cast<xmlDocPtr>(doc.get_doc_data());
-    std::auto_ptr<pimpl> ap(pimpl_ = new pimpl);
+    xml::impl::auto_ptr<pimpl> ap(pimpl_ = new pimpl);
 
     if ( (pimpl_->ss_ = xsltParseStylesheetDoc(xmldoc)) == 0)
     {


### PR DESCRIPTION
Fix deprecation warnings due to the use of `std::auto_ptr<>` and test C++11 build on Travis.