### PR TITLE
Fix crashes in some of xslt::stylesheet::apply() overloads

### DIFF
--- a/src/libxslt/stylesheet.cxx
+++ b/src/libxslt/stylesheet.cxx
@@ -289,6 +289,12 @@ xml::document& xslt::stylesheet::apply(const xml::document &doc,
     xmlDocPtr input = static_cast<xmlDocPtr>(doc.get_doc_data_read_only());
     xmlDocPtr xmldoc = apply_stylesheet(pimpl_, on_error, input);
 
+    if (!xmldoc)
+    {
+        // More detailed error information is available from on_error.
+        throw xml::exception("applying style sheet failed");
+    }
+
     pimpl_->doc_.set_doc_data_from_xslt(xmldoc, new result_impl(xmldoc, pimpl_->ss_));
     return pimpl_->doc_;
 }
@@ -300,6 +306,12 @@ xml::document& xslt::stylesheet::apply(const xml::document &doc,
 {
     xmlDocPtr input = static_cast<xmlDocPtr>(doc.get_doc_data_read_only());
     xmlDocPtr xmldoc = apply_stylesheet(pimpl_, on_error, input, &with_params);
+
+    if (!xmldoc)
+    {
+        // More detailed error information is available from on_error.
+        throw xml::exception("applying style sheet failed");
+    }
 
     pimpl_->doc_.set_doc_data_from_xslt(xmldoc, new result_impl(xmldoc, pimpl_->ss_));
     return pimpl_->doc_;


### PR DESCRIPTION
If the provided on_error handler doesn't throw an exception (e.g. if it's an
xml::error_messages object), don't crash in apply() overloads returning the
result of the transformation.

Just check for apply_stylesheet() success there too, just as it was already
done in the overloads using the "result" document object.

---

Another alternative would be documenting that `on_error` **must** throw when using these overloads, but I think it's a poor choice to crash when we can avoid it.

BTW, as discussed [here](http://lists.nongnu.org/archive/html/lmi/2016-07/msg00039.html), I think it's a bad idea to throw an exception with only the first error by default, IMO we should throw all combined errors by default to avoid losing valuable information. I could make another PR for this if you agree.