### PR TITLE
Use reasonably maximal warning level for MSVS projects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Version 0.8.0
+
+    New behaviour: xml::document::save_to_{string,file}() now throws exception
+    in case of failure by default instead of filently ignoring any errors.
+
+    Extend xpath_context::evaluate() to optionally throw an exception if an
+    invalid XPath expression is specified.
 
     Added xml::node::move_under().
     Added xml::node::set_namespace().

--- a/include/xmlwrapp/document.h
+++ b/include/xmlwrapp/document.h
@@ -453,21 +453,36 @@ public:
         Convert the XML document tree into XML text data and place it into
         the given string.
 
+        Any errors occurring while converting the document to string are passed
+        to @a on_error handler. By default, an exception will be thrown if
+        anything goes wrong.
+
         @param s The string to place the XML text data.
+        @param on_error Handler called to process errors and warnings (new
+            since 0.8.0).
      */
-    void save_to_string(std::string& s) const;
+    void save_to_string(std::string& s, error_handler& on_error = throw_on_error) const;
 
     /**
         Convert the XML document tree into XML text data and place it into
         the given filename.
 
+        This function throws an exception if saving fails for any reason by
+        default and allows to customize this behaviour by passing a non-default
+        @a on_error handler.
+
         @param filename The name of the file to place the XML text data into.
+        @param on_error Handler called to process errors and warnings (new
+            since 0.8.0).
         @param compression_level 0 is no compression, 1-9 allowed, where 1 is
                                  for better speed, and 9 is for smaller size
         @return True if the data was saved successfully.
-        @return False otherwise.
+        @return False otherwise (notice that this is only possible if a custom
+            error handler not throwing on error is specified).
      */
-    bool save_to_file(const char *filename, int compression_level = 0) const;
+    bool save_to_file(const char *filename,
+                      int compression_level = 0,
+                      error_handler& on_error = throw_on_error) const;
 
     /**
         Convert the XML document tree into XML text data and then insert it

--- a/include/xmlwrapp/errors.h
+++ b/include/xmlwrapp/errors.h
@@ -95,6 +95,18 @@ public:
 
 
 /**
+    An error handler that ignores both errors and warnings.
+
+    @see ignore_errors
+ */
+class error_handler_ignore_errors : public error_handler
+{
+public:
+    void on_error(const std::string&) {}
+    void on_warning(const std::string&) {}
+};
+
+/**
     Specialization of error_handler that throws on any error.
 
     @see throw_on_error
@@ -116,6 +128,9 @@ class error_handler_throw_on_error_or_warning : public error_handler_throw_on_er
 public:
     void on_warning(const std::string& msg) { on_error(msg); }
 };
+
+/// Error handler ignoring all errors, its use is strongly discouraged.
+extern XMLWRAPP_API error_handler_ignore_errors              ignore_errors;
 
 /// Error handler object that throws on any error.
 extern XMLWRAPP_API error_handler_throw_on_error             throw_on_error;

--- a/include/xmlwrapp/xpath.h
+++ b/include/xmlwrapp/xpath.h
@@ -43,6 +43,7 @@
 
 // xmlwrapp includes
 #include "xmlwrapp/init.h"
+#include "xmlwrapp/errors.h"
 #include "xmlwrapp/export.h"
 #include "xmlwrapp/nodes_view.h"
 
@@ -97,35 +98,41 @@ public:
     /**
         Execute an XPath query in the document scope.
 
-        Notice that the returned view is const; if you need to modify nodes in
-        the returned set, use the non-const overload that takes xml::node&
-        argument and pass xml::document::get_root_node() result to it.
+        Calling this function is exactly equivalent to using the overload
+        taking an xml::node argument with xml::document::get_root_node().
 
-        @param  expr  XPath expression.
-
-        @return Const set of matching nodes.
+        In particular, this implies that if you need to modify nodes in the
+        returned set, you can simple use the non-const overload taking
+        xml::node& argument and pass xml::document::get_root_node() result to
+        it.
      */
-    const_nodes_view evaluate(const std::string& expr);
+    const_nodes_view evaluate(const std::string& expr,
+                              error_handler& on_error = ignore_errors);
 
     /**
         Execute an XPath query in the scope of XML node @a n.
 
         @param  expr  XPath expression.
         @param  n     The context node for the expression.
+        @param  on_error Error handler ignoring all errors by default for
+            compatibility reasons: in case of an error, an empty set is
+            returned.
 
         @return Const set of matching nodes.
      */
-    const_nodes_view evaluate(const std::string& expr, const xml::node& n);
+    const_nodes_view evaluate(const std::string& expr,
+                              const xml::node& n,
+                              error_handler& on_error = ignore_errors);
 
     /**
         Execute an XPath query in the scope of XML node @a n.
 
-        @param  expr  XPath expression.
-        @param  n     The context node for the expression.
-
-        @return Set of matching nodes.
+        This overload is identical to the one taking const @a n argument,
+        except that it returns a set of nodes that can be modified.
      */
-    nodes_view evaluate(const std::string& expr, xml::node& n);
+    nodes_view evaluate(const std::string& expr,
+                        xml::node& n,
+                        error_handler& on_error = ignore_errors);
 
 private:
     // no copying

--- a/platform/Win32/xmlwrapp.bkl
+++ b/platform/Win32/xmlwrapp.bkl
@@ -28,6 +28,8 @@ defines += _CRT_SECURE_NO_DEPRECATE
            _SCL_SECURE_NO_WARNINGS;
 
 
+warnings = all;
+
 library xmlwrapp {
     headers {
         include/xmlwrapp/attributes.h

--- a/platform/Win32/xmlwrapp.bkl
+++ b/platform/Win32/xmlwrapp.bkl
@@ -92,3 +92,31 @@ library xsltwrapp {
         src/libxslt/stylesheet.cxx
     }
 }
+
+program test {
+    includedirs = include;
+
+    // zlib is not always available under Windows, so don't use it by default,
+    // it's only used by a single test and it's not worth the trouble.
+    defines += XMLWRAPP_NO_ZLIB;
+
+    deps = xmlwrapp xsltwrapp;
+
+    libs = libexslt libxslt libxml2;
+
+    headers {
+        tests/test.h
+    }
+
+    sources {
+        tests/test_main.cxx
+        tests/attributes/test_attributes.cxx
+        tests/document/test_document.cxx
+        tests/event/test_event.cxx
+        tests/node/test_node.cxx
+        tests/schema/test_schema.cxx
+        tests/tree/test_tree.cxx
+        tests/xpath/test_xpath.cxx
+        tests/xslt/test_xslt.cxx
+    }
+}

--- a/src/libxml/document.cxx
+++ b/src/libxml/document.cxx
@@ -37,6 +37,7 @@
 #include "xmlwrapp/errors.h"
 #include "xmlwrapp/tree_parser.h"
 
+#include "errors_impl.h"
 #include "utility.h"
 #include "cpp11.h"
 #include "dtd_impl.h"
@@ -445,41 +446,68 @@ node::iterator document::erase(node::iterator first, node::iterator last)
 }
 
 
-void document::save_to_string(std::string& s) const
+void document::save_to_string(std::string& s, error_handler& on_error) const
 {
-    xmlChar *xml_string;
-    int xml_string_length;
+    impl::global_errors_collector err;
 
     if (pimpl_->xslt_result_ != 0)
     {
         pimpl_->xslt_result_->save_to_string(s);
-        return;
+    }
+    else
+    {
+        xmlChar *xml_string;
+        int xml_string_length;
+
+        const char *enc = pimpl_->encoding_.empty() ? 0 : pimpl_->encoding_.c_str();
+        xmlDocDumpFormatMemoryEnc(pimpl_->doc_, &xml_string, &xml_string_length, enc, 1);
+
+        xmlchar_helper helper(xml_string);
+        if (xml_string_length)
+            s.assign(helper.get(), xml_string_length);
     }
 
-    const char *enc = pimpl_->encoding_.empty() ? 0 : pimpl_->encoding_.c_str();
-    xmlDocDumpFormatMemoryEnc(pimpl_->doc_, &xml_string, &xml_string_length, enc, 1);
-
-    xmlchar_helper helper(xml_string);
-    if (xml_string_length)
-        s.assign(helper.get(), xml_string_length);
+    err.replay(on_error);
 }
 
 
-bool document::save_to_file(const char *filename, int compression_level) const
+bool document::save_to_file(const char *filename, int compression_level, error_handler& on_error) const
 {
-    std::swap(pimpl_->doc_->compression, compression_level);
+    impl::global_errors_collector err;
 
+    // Helper to temporarily change document compression parameter.
+    class set_compression_in_scope
+    {
+    public:
+        set_compression_in_scope(xmlDocPtr doc, int compression_level) :
+            doc_(doc),
+            compression_level_orig_(doc_->compression)
+        {
+            doc_->compression = compression_level;
+        }
+
+        ~set_compression_in_scope()
+        {
+            doc_->compression = compression_level_orig_;
+        }
+
+    private:
+        const xmlDocPtr doc_;
+        const int compression_level_orig_;
+    } set_compression(pimpl_->doc_, compression_level);
+
+    bool rc;
     if (pimpl_->xslt_result_ != 0)
     {
-        bool rc = pimpl_->xslt_result_->save_to_file(filename, compression_level);
-        std::swap(pimpl_->doc_->compression, compression_level);
-
-        return rc;
+        rc = pimpl_->xslt_result_->save_to_file(filename, compression_level);
+    }
+    else
+    {
+        const char *enc = pimpl_->encoding_.empty() ? 0 : pimpl_->encoding_.c_str();
+        rc = xmlSaveFormatFileEnc(filename, pimpl_->doc_, enc, 1) > 0;
     }
 
-    const char *enc = pimpl_->encoding_.empty() ? 0 : pimpl_->encoding_.c_str();
-    bool rc = xmlSaveFormatFileEnc(filename, pimpl_->doc_, enc, 1) > 0;
-    std::swap(pimpl_->doc_->compression, compression_level);
+    err.replay(on_error);
 
     return rc;
 }

--- a/src/libxml/document.cxx
+++ b/src/libxml/document.cxx
@@ -198,7 +198,7 @@ document::document(const node& n)
 
 document::document(const char *filename, error_handler& on_error)
 {
-    pimpl_ = new doc_impl;
+    pimpl_ = NULL;
     tree_parser p(filename, on_error);
     if ( !p )
         throw exception(p.messages());
@@ -207,7 +207,7 @@ document::document(const char *filename, error_handler& on_error)
 
 document::document(const char *data, size_type size, error_handler& on_error)
 {
-    pimpl_ = new doc_impl;
+    pimpl_ = NULL;
     tree_parser p(data, size, on_error);
     if ( !p )
         throw exception(p.messages());

--- a/src/libxml/errors.cxx
+++ b/src/libxml/errors.cxx
@@ -39,6 +39,7 @@
 namespace xml
 {
 
+error_handler_ignore_errors              ignore_errors;
 error_handler_throw_on_error             throw_on_error;
 error_handler_throw_on_error_or_warning  throw_on_error_or_warning;
 
@@ -190,6 +191,22 @@ std::string errors_collector::format_for_print(const error_message& msg) const
     }
 
     return msg.message(); // silence bogus gcc warning
+}
+
+// ----------------------------------------------------------------------------
+// global_errors_installer
+// ----------------------------------------------------------------------------
+
+global_errors_installer::global_errors_installer(error_messages& on_error) :
+    xml_error_orig_(xmlGenericError),
+    xml_error_context_orig_(xmlGenericErrorContext)
+{
+    xmlSetGenericErrorFunc(&on_error, cb_messages_error);
+}
+
+global_errors_installer::~global_errors_installer()
+{
+    xmlSetGenericErrorFunc(xml_error_context_orig_, xml_error_orig_);
 }
 
 } // namespace impl

--- a/src/libxml/errors_impl.h
+++ b/src/libxml/errors_impl.h
@@ -35,6 +35,7 @@
 
 #include <stdarg.h>
 #include <xmlwrapp/errors.h>
+#include <libxml/xmlerror.h>
 
 namespace xml
 {
@@ -53,6 +54,42 @@ public:
 
 protected:
     virtual std::string format_for_print(const error_message& msg) const;
+};
+
+// RAII helper installing the given error collector as the global error sink
+// for libxml2 error messages.
+class XMLWRAPP_API global_errors_installer
+{
+public:
+    // The object given as argument must have lifetime greater than that of
+    // this object itself.
+    explicit global_errors_installer(error_messages& on_error);
+    ~global_errors_installer();
+
+private:
+    global_errors_installer(const global_errors_installer&);
+    global_errors_installer& operator=(const global_errors_installer&);
+
+    xmlGenericErrorFunc xml_error_orig_;
+    void *xml_error_context_orig_;
+};
+
+// This class behaves like error_collector but also installs itself as handler
+// for global libxml2 errors, i.e. those that happen outside of any other
+// context.
+class global_errors_collector :
+    public errors_collector,
+    private global_errors_installer
+{
+public:
+    global_errors_collector() :
+        global_errors_installer(static_cast<error_messages&>(*this))
+    {
+    }
+
+private:
+    global_errors_collector(const global_errors_collector&);
+    global_errors_collector& operator=(const global_errors_collector&);
 };
 
 // These functions can be used as error callbacks in various libxml2 functions.

--- a/src/libxml/init.cxx
+++ b/src/libxml/init.cxx
@@ -39,16 +39,6 @@
 #include <libxml/xmlerror.h>
 #include <libxml/parser.h>
 
-extern "C"
-{
-
-static void xml_error(void *, const char*, ...)
-{
-    // don't do anything
-}
-
-} // extern "C"
-
 namespace xml
 {
 
@@ -76,9 +66,6 @@ void init::init_library()
     substitute_entities(true);
     load_external_subsets(true);
     validate_xml(false);
-
-    // keep libxml2 from using stderr
-    xmlSetGenericErrorFunc(0, xml_error);
 
     // init the parser (keeps libxml2 thread safe)
     xmlInitParser();

--- a/src/libxml/node.cxx
+++ b/src/libxml/node.cxx
@@ -688,7 +688,7 @@ node::const_iterator node::find(const char *name) const
 node::iterator node::find(const char *name, const iterator& start)
 {
     xmlNodePtr n = static_cast<xmlNodePtr>(start.get_raw_node());
-    if ( (n = find_element(name, n)))
+    if ((n = find_element(name, n)) != NULL)
         return iterator(n);
     return end();
 }
@@ -697,7 +697,7 @@ node::iterator node::find(const char *name, const iterator& start)
 node::const_iterator node::find(const char *name, const const_iterator& start) const
 {
     xmlNodePtr n = static_cast<xmlNodePtr>(start.get_raw_node());
-    if ( (n = find_element(name, n)))
+    if ((n = find_element(name, n)) != NULL)
         return const_iterator(n);
     return end();
 }

--- a/src/libxslt/stylesheet.cxx
+++ b/src/libxslt/stylesheet.cxx
@@ -156,6 +156,8 @@ xmlDocPtr apply_stylesheet(xslt::stylesheet::pimpl *impl,
     ctxt->_private = impl;
 
     xslt_errors_collector err(ctxt);
+    xml::impl::global_errors_installer install_as_global(err);
+
     xsltSetTransformErrorFunc(ctxt, &err, xml::impl::cb_messages_error);
 
     xmlDocPtr result =

--- a/tests/document/test_document.cxx
+++ b/tests/document/test_document.cxx
@@ -34,7 +34,17 @@
 #include "../test.h"
 
 #include <boost/iostreams/filtering_stream.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
+
+// Allow disabling the test using zlib if it's not available.
+// Also never compile this test with Sun CC as it fails to compile
+// gzip_decompressor() anyhow.
+#if !defined(XMLWRAPP_NO_ZLIB) && !defined(__SUNPRO_CC)
+    #define XMLWRAPP_USE_ZLIB
+#endif
+
+#ifdef XMLWRAPP_USE_ZLIB
+    #include <boost/iostreams/filter/gzip.hpp>
+#endif
 
 BOOST_AUTO_TEST_SUITE( document )
 
@@ -413,7 +423,7 @@ BOOST_AUTO_TEST_CASE( save_to_file )
 }
 
 
-#ifndef __SUNPRO_CC // SunCC can't compile gzip_decompressor
+#ifdef XMLWRAPP_USE_ZLIB
 BOOST_AUTO_TEST_CASE( save_to_file_gzip )
 {
     xml::document doc(xml::node("root"));
@@ -433,7 +443,7 @@ BOOST_AUTO_TEST_CASE( save_to_file_gzip )
 
     remove(TEST_FILE);
 }
-#endif // !__SUNPRO_CC
+#endif // XMLWRAPP_USE_ZLIB
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/document/test_document.cxx
+++ b/tests/document/test_document.cxx
@@ -266,20 +266,20 @@ BOOST_AUTO_TEST_CASE( process_xinclude )
 BOOST_AUTO_TEST_CASE( size )
 {
     xml::document doc_01(xml::node("root"));
-    BOOST_CHECK_EQUAL( doc_01.size(), 1 );
+    BOOST_CHECK_EQUAL( doc_01.size(), 1u );
 
     doc_01.push_back(xml::node(xml::node::comment("This is a comment")));
-    BOOST_CHECK_EQUAL( doc_01.size(), 2 );
+    BOOST_CHECK_EQUAL( doc_01.size(), 2u );
 
     xml::document doc_02(doc_01);
-    BOOST_CHECK_EQUAL( doc_02.size(), 2 );
+    BOOST_CHECK_EQUAL( doc_02.size(), 2u );
 
     xml::document doc_03;
-    BOOST_CHECK_EQUAL( doc_03.size(), 1 );
+    BOOST_CHECK_EQUAL( doc_03.size(), 1u );
 
     xml::node n("root");
     xml::document doc_04(n);
-    BOOST_CHECK_EQUAL( doc_04.size(), 1 );
+    BOOST_CHECK_EQUAL( doc_04.size(), 1u );
 }
 
 

--- a/tests/document/test_document.cxx
+++ b/tests/document/test_document.cxx
@@ -403,7 +403,33 @@ BOOST_AUTO_TEST_CASE( cant_erase_root )
 }
 
 
-static const char *TEST_FILE = "test_temp_file";
+// Simple RAII helper to remove a temporary test file.
+class temp_test_file
+{
+public:
+    temp_test_file() :
+        used_(false)
+    {
+    }
+
+    ~temp_test_file()
+    {
+        if (used_)
+            remove(get_name());
+    }
+
+    const char *get_name()
+    {
+        used_ = true;
+        return "test_temp_file";
+    }
+
+private:
+    bool used_;
+
+    temp_test_file(const temp_test_file&);
+    temp_test_file& operator=(const temp_test_file&);
+};
 
 /*
  * These tests check xml::docment::save_to_file()
@@ -414,12 +440,32 @@ BOOST_AUTO_TEST_CASE( save_to_file )
     xml::document doc(xml::node("root"));
     doc.get_root_node().push_back(xml::node("child"));
 
-    doc.save_to_file(TEST_FILE);
+    temp_test_file test_file;
+    doc.save_to_file(test_file.get_name());
 
-    std::ifstream stream(TEST_FILE);
+    std::ifstream stream(test_file.get_name());
     BOOST_CHECK( is_same_as_file(read_file_into_string(stream), "document/data/15.out") );
+}
 
-    remove(TEST_FILE);
+
+BOOST_AUTO_TEST_CASE( save_throws_on_failure )
+{
+    xml::document doc(xml::node("root"));
+    doc.get_root_node().push_back(xml::node(xml::node::text("invalid character: \x7")));
+
+    std::string s;
+    BOOST_CHECK_THROW
+    (
+        doc.save_to_string(s),
+        xml::exception
+    );
+
+    temp_test_file test_file;
+    BOOST_CHECK_THROW
+    (
+        doc.save_to_file(test_file.get_name()),
+        xml::exception
+    );
 }
 
 
@@ -429,19 +475,18 @@ BOOST_AUTO_TEST_CASE( save_to_file_gzip )
     xml::document doc(xml::node("root"));
     doc.get_root_node().push_back(xml::node("child"));
 
-    doc.save_to_file(TEST_FILE, 9);
+    temp_test_file test_file;
+    doc.save_to_file(test_file.get_name(), 9);
 
     // verify that the file was can be read back as compressed
-    std::ifstream stream(TEST_FILE);
+    std::ifstream stream(test_file.get_name());
     boost::iostreams::filtering_stream<boost::iostreams::input> filter;
     filter.push(boost::iostreams::gzip_decompressor());
     filter.push(stream);
     BOOST_CHECK( is_same_as_file(read_file_into_string(filter), "document/data/15.out") );
 
     // ...and by libxml2 directly too
-    xml::tree_parser parser(TEST_FILE);
-
-    remove(TEST_FILE);
+    xml::tree_parser parser(test_file.get_name());
 }
 #endif // XMLWRAPP_USE_ZLIB
 

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE( elements )
     xml::node &root = parser.get_document().get_root_node();
     xml::nodes_view persons(root.elements("person"));
 
-    BOOST_CHECK_EQUAL( persons.size(), 3 );
+    BOOST_CHECK_EQUAL( persons.size(), 3u );
 
     std::ostringstream ostr;
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE( elements_const )
     const xml::node &root = parser.get_document().get_root_node();
     xml::const_nodes_view persons(root.elements("person"));
 
-    BOOST_CHECK_EQUAL( persons.size(), 3 );
+    BOOST_CHECK_EQUAL( persons.size(), 3u );
 
     std::ostringstream ostr;
 
@@ -453,13 +453,13 @@ BOOST_AUTO_TEST_CASE( node_empty )
 BOOST_AUTO_TEST_CASE( node_size )
 {
     xml::node n("root");
-    BOOST_CHECK_EQUAL( n.size(), 0 );
+    BOOST_CHECK_EQUAL( n.size(), 0u );
 
     n.push_back(xml::node("one"));
-    BOOST_CHECK_EQUAL( n.size(), 1 );
+    BOOST_CHECK_EQUAL( n.size(), 1u );
 
     n.push_back(xml::node("two"));
-    BOOST_CHECK_EQUAL( n.size(), 2 );
+    BOOST_CHECK_EQUAL( n.size(), 2u );
 }
 
 /*

--- a/tests/test.h
+++ b/tests/test.h
@@ -33,8 +33,12 @@
 #ifndef _xmlwrapp_test_h_
 #define _xmlwrapp_test_h_
 
-#define BOOST_TEST_ALTERNATIVE_INIT_API
-#define BOOST_TEST_DYN_LINK
+// XMLWRAPP_NO_BOOST_TEST_DYN_LINK can be predefined in the compiler options if
+// you have Boost Unit Test Framework as a static library and not a shared one.
+#ifndef XMLWRAPP_NO_BOOST_TEST_DYN_LINK
+    #define BOOST_TEST_ALTERNATIVE_INIT_API
+    #define BOOST_TEST_DYN_LINK
+#endif
 
 #include <boost/test/unit_test.hpp>
 

--- a/tests/tree/test_tree.cxx
+++ b/tests/tree/test_tree.cxx
@@ -144,8 +144,7 @@ BOOST_AUTO_TEST_CASE( bad_xml_data_throw )
 BOOST_AUTO_TEST_CASE( nonexistent_file )
 {
     xml::tree_parser parser("doesnt_exist.xml", false);
-    BOOST_CHECK_EQUAL( parser.messages().print(),
-                       "failed to open file \"doesnt_exist.xml\"" );
+    BOOST_CHECK( parser.messages().print().find("doesnt_exist.xml") != std::string::npos );
     BOOST_CHECK( !parser ); // failed
 }
 

--- a/tests/xpath/test_xpath.cxx
+++ b/tests/xpath/test_xpath.cxx
@@ -107,10 +107,15 @@ BOOST_AUTO_TEST_CASE (illegal_xpath)
 {
     xml::tree_parser parser(test_file_path("xpath/data/02.xml").c_str());
     xml::xpath_context ctxt(parser.get_document());
-    
-    xml::const_nodes_view ns = ctxt.evaluate("ILLEGAL XPATH-QUERY");
 
+    xml::const_nodes_view ns = ctxt.evaluate("ILLEGAL XPATH-QUERY");
     BOOST_CHECK(ns.begin() == ns.end());
+
+    BOOST_CHECK_THROW
+    (
+        ctxt.evaluate("ANOTHER ILLEGAL QUERY", xml::throw_on_error),
+        xml::exception
+    );
 }
 
 


### PR DESCRIPTION
Use bakefile "all" warnings level and fix two warnings that appeared when
using it with MSVS 2015.