### PR TITLE
Don't leak memory when creating a document object fails

### DIFF
--- a/src/libxml/document.cxx
+++ b/src/libxml/document.cxx
@@ -198,7 +198,7 @@ document::document(const node& n)
 
 document::document(const char *filename, error_handler& on_error)
 {
-    pimpl_ = new doc_impl;
+    pimpl_ = NULL;
     tree_parser p(filename, on_error);
     if ( !p )
         throw exception(p.messages());
@@ -207,7 +207,7 @@ document::document(const char *filename, error_handler& on_error)
 
 document::document(const char *data, size_type size, error_handler& on_error)
 {
-    pimpl_ = new doc_impl;
+    pimpl_ = NULL;
     tree_parser p(data, size, on_error);
     if ( !p )
         throw exception(p.messages());


### PR DESCRIPTION
There is no need to allocate a new doc_impl when creating a document from file
or data, it's not used at all in the normal case after a call to swap() and is
simply leaked if an error occurs.

This fixes memory leak reports from MSVC debug CRT and, perhaps more
importantly, avoids an unnecessary allocation in the normal case.