### PR TITLE
Improve libxml2 error reporting by including more details

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 0.9.2
+
+    Improve error reporting again by including more details. This changes the
+    error messages format compared to the previous versions.
+
 Version 0.9.1
 
     Added return value for xml::init methods setting various boolean flags:

--- a/src/libxml/errors_impl.h
+++ b/src/libxml/errors_impl.h
@@ -70,8 +70,11 @@ private:
     global_errors_installer(const global_errors_installer&);
     global_errors_installer& operator=(const global_errors_installer&);
 
-    xmlGenericErrorFunc xml_error_orig_;
-    void *xml_error_context_orig_;
+    xmlGenericErrorFunc xml_generic_error_orig_;
+    void *xml_generic_error_context_orig_;
+
+    xmlStructuredErrorFunc xml_structured_error_orig_;
+    void *xml_structured_error_context_orig_;
 };
 
 // This class behaves like error_collector but also installs itself as handler
@@ -97,6 +100,8 @@ private:
 // Usage: pass the pointer to errors_collector as libxml2's void* ctx argument
 extern "C"
 {
+
+XMLWRAPP_API void cb_messages_structured_error(void *out, xmlErrorPtr error);
 
 XMLWRAPP_API void cb_messages_warning(void *out, const char *message, ...);
 XMLWRAPP_API void cb_messages_error(void *out, const char *message, ...);

--- a/tests/document/test_document.cxx
+++ b/tests/document/test_document.cxx
@@ -398,6 +398,20 @@ TEST_CASE_METHOD( SrcdirConfig, "document/cant_erase_root", "[document]" )
 }
 
 
+/*
+ * This test checks xml::tree_parser ctor to make sure it throws an
+ * exception containing the name of the input file in its message.
+ */
+TEST_CASE_METHOD( SrcdirConfig, "document/error_from_ctor", "[document][error]" )
+{
+    CHECK_THROWS_WITH
+    (
+        xml::tree_parser("bloordyblop.xml"),
+        Catch::Contains("bloordyblop.xml")
+    );
+}
+
+
 // Simple RAII helper to remove a temporary test file.
 class temp_test_file
 {


### PR DESCRIPTION
Previous attempts to report errors better were insufficient as the generic
error handler in libxml2 is used multiple times when reporting errors by
libxml2 and as we threw after getting the first one, it resulted in such error
message as "I/O " (and nothing else) when failing to load a file.

Fix this by setting up the structured error handler which is called atomically
and also provides more information than what is passed to the generic handler.
Notice that we still need to continue using generic error handler as some
places in libxml2 only use it and not the structured handler.

Add a unit test verifying that the name of the file which couldn't be opened
appears in the error message of the exception thrown in this case.