### PR TITLE
Avoid annoying warnings from ar included in recent binutils

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,16 @@ dnl === Program checks ===
 
 AC_PROG_CXX
 AC_PROG_LD
+
+dnl This is a workaround for the harmless but annoying warning
+dnl
+dnl ar: `u' modifier ignored since `D' is the default (see `U')
+dnl
+dnl given by Linux systems using recent binutils with the switch to building
+dnl deterministic archives (that can't include the timestamps) when building
+dnl all static libraries with default "cru" flags used by Libtool up to 2.4.6.
+AR_FLAGS=cr
+
 AC_PROG_LIBTOOL
 
 


### PR DESCRIPTION
Explicitly set AR_FLAGS to "cr" to override the default value of "cru" used by
libtool which results in warnings about not supported any more "u" option from
all currently used versions of ar under Linux -- as we don't really care about
the tiny extra efficiency from using "u", just stop using it completely.