### PR TITLE
Fix crash when initializing the library from multiple threads

### DIFF
--- a/src/libxml/init.cxx
+++ b/src/libxml/init.cxx
@@ -60,15 +60,15 @@ init::~init()
 
 void init::init_library()
 {
+    // init the parser (keeps libxml2 thread safe)
+    xmlInitParser();
+
     // set some libxml global variables
     indent_output(true);
     remove_whitespace(false);
     substitute_entities(true);
     load_external_subsets(true);
     validate_xml(false);
-
-    // init the parser (keeps libxml2 thread safe)
-    xmlInitParser();
 }
 
 


### PR DESCRIPTION
Call xmlInitParser() before setting libxml2 global variables as these
"variables" actually are function calls using global state protected by a
critical section that must be initialized by xmlInitParser() before being
used.

This fixes a crash due to trying to enter an uninitialized critical section
under MSW.

---

The fix is trivial but it was fun to find because the crash occurred when loading a (plugin) DLL that used xmlwrapp and so the sporadically occurring error was "failed to load DLL"...