### PR TITLE
Always use UTF-8 encoding by default in xml::document

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Version [unreleased]
+
+    Slight behaviour change: always use UTF-8, not ISO-8859-1, as default
+    encoding. This was already the case before, but calling get_encoding()
+    (not "set"!) changed the default to ISO-8859-1 as a side effect and this
+    is not done any longer.
+
 Version 0.8.1
 
     Add cpp11.h file missing from 0.8.0 distribution archive.

--- a/include/xmlwrapp/document.h
+++ b/include/xmlwrapp/document.h
@@ -219,15 +219,18 @@ public:
 
     /**
         Get the XML encoding for this document. The default encoding is
-        ISO-8859-1.
+        UTF-8.
 
         @return The encoding string.
      */
-    const std::string& get_encoding() const;
+    std::string get_encoding() const;
 
     /**
         Set the XML encoding string. If you don't set this, it will default
-        to ISO-8859-1.
+        to UTF-8.
+
+        Note that all strings in the XML document must be encoded in the
+        document encoding.
 
         @param encoding The XML encoding to use.
      */


### PR DESCRIPTION
This was already mostly the case, i.e. UTF-8 was (implicitly) used if
set_encoding() had been never called, but the default encoding was
change to ISO-8859-1 if get_encoding() was called, even without any
preceding set_encoding() call, which didn't make any sense at all.

So stop changing the default encoding in get_encoding() and just return
"UTF-8" from it if no encoding had been previously set.

This change also allows us to get rid of unnecessary doc_impl::encoding_
variable which, other than being used in the get_encoding() hack
described above, seemed to exist solely in order to allow returning a
reference to it from document::get_encoding(), but this seems
unnecessary when we can just return the string by value (which is mostly
backwards compatible with the existing code) and removing this variable
simplifies the code as we don't need to keep it in sync with the
encoding stored in xmlDocPtr any more.

Also stop using xmlDocDumpFormatMemoryEnc() and xmlSaveFormatFileEnc()
when we can use the simpler functions without the "Enc" suffix doing the
same thing anyhow.