### PR TITLE
Allow running autoreconf

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -58,15 +58,14 @@ run_optional_tool() {
     fi
 }
 
-# use --foreign with automake because we lack standard GNU NEWS and AUTHOR
-# files, if they're added we can "upgrade" to (default) GNU strictness. Use
-# --copy to allow simultaneous use on windows under mingw and cygwin platforms.
-# Symlinking of files under mingw does not work out for cygwin and vice-versa.
+# Use --copy with automake to allow simultaneous use on windows under mingw and
+# cygwin platforms. Symlinking of files under mingw does not work out for
+# cygwin and vice-versa.
 echo "Setting up build system for xmlwrapp:"
 echo " - aclocal " && aclocal -I admin && \
 echo " - libtoolize " && $LIBTOOLIZE --copy --automake && \
 echo " - autoconf " && autoconf && \
-echo " - automake " && automake --add-missing --copy --foreign && \
+echo " - automake " && automake --add-missing --copy && \
 echo " - doxygen "  && run_optional_tool docs doxygen && \
 echo " - bakefile " && run_optional_tool platform/Win32 bkl xmlwrapp.bkl && \
 echo "Build setup successful, type \"configure\" to configure xmlwrapp now." && \

--- a/bootstrap
+++ b/bootstrap
@@ -62,7 +62,7 @@ run_optional_tool() {
 # cygwin platforms. Symlinking of files under mingw does not work out for
 # cygwin and vice-versa.
 echo "Setting up build system for xmlwrapp:"
-echo " - aclocal " && aclocal -I admin && \
+echo " - aclocal " && aclocal && \
 echo " - libtoolize " && $LIBTOOLIZE --copy --automake && \
 echo " - autoconf " && autoconf && \
 echo " - automake " && automake --add-missing --copy && \

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_INIT(xmlwrapp, 0.8.1, [xmlwrapp@googlegroups.com])
 
 AC_CONFIG_SRCDIR([xmlwrapp.pc.in])
 AC_CONFIG_AUX_DIR([admin])
+AC_CONFIG_MACRO_DIR([admin])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_INIT(xmlwrapp, 0.8.1, [xmlwrapp@googlegroups.com])
 AC_CONFIG_SRCDIR([xmlwrapp.pc.in])
 AC_CONFIG_AUX_DIR([admin])
 
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
I got used to running `autoreconf` (about which I simply didn't know back when I started writing `bootstrap` or `bootstrap.sh` or `autogen.sh` or whatever scripts for different projects...) recently and was annoyed that it didn't work with xmlwrapp, so I've fixed the 2 small problems which prevented it from working.

Additionally, I think the changes are useful even when not using autoreconf as it's better to keep all the options in a single place.