### PR TITLE
Add return value to xml::init methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 0.9.1 [not released yet]
+
+    Added return value for xml::init methods setting various boolean flags:
+    they now return the previous state of the flag.
+
 Version 0.9.0
 
     Slight behaviour change: always use UTF-8, not ISO-8859-1, as default

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,9 @@
 Version 0.9.1 [not released yet]
 
     Added return value for xml::init methods setting various boolean flags:
-    they now return the previous state of the flag.
+    they now return the previous state of the flag. Also add
+    xml::init::change_flag helper to facilitate temporarily changing some
+    global flag.
 
 Version 0.9.0
 

--- a/include/xmlwrapp/init.h
+++ b/include/xmlwrapp/init.h
@@ -72,8 +72,9 @@ public:
         node tree. The default is true.
 
         @param flag True to turn on indenting, false to turn it off.
+        @return previous state of the flag.
      */
-    static void indent_output(bool flag);
+    static bool indent_output(bool flag);
 
     /**
         This member function controls whether or not the XML parser should
@@ -81,16 +82,18 @@ public:
         is false.
 
         @param flag True to remove whitespace, false to leave alone.
+        @return previous state of the flag.
      */
-    static void remove_whitespace(bool flag);
+    static bool remove_whitespace(bool flag);
 
     /**
         This member function controls whether or not the XML parser should
         substitute entities while parsing. The default is true.
 
         @param flag True to turn on substitution, false to turn off.
+        @return previous state of the flag.
      */
-    static void substitute_entities(bool flag);
+    static bool substitute_entities(bool flag);
 
     /**
         This member function controls whether or not the XML parser should
@@ -99,8 +102,9 @@ public:
         default is true.
 
         @param flag True to turn on loading, false to turn it off.
+        @return previous state of the flag.
      */
-    static void load_external_subsets(bool flag);
+    static bool load_external_subsets(bool flag);
 
     /**
         This member function controls whether or not the XML parser should
@@ -108,8 +112,9 @@ public:
         is false.
 
         @return flag True to turn on validation, false to turn it off.
+        @return previous state of the flag.
      */
-    static void validate_xml(bool flag);
+    static bool validate_xml(bool flag);
 
 private:
     init(const init&);

--- a/include/xmlwrapp/init.h
+++ b/include/xmlwrapp/init.h
@@ -67,6 +67,59 @@ public:
     ~init();
 
     /**
+        RAII helper changing some global XML library flag only for the duration
+        of its lifetime.
+
+        Example use:
+        @code
+        void some_function()
+        {
+            if ( whatever )
+            {
+                xml::init::change_flag change(&xml::init::substitute_entities, false);
+
+                // entities are not substituted here
+            }
+
+            // entities substitution flag reverted to its original value here
+        }
+        @endcode
+
+        @since 0.9.1
+     */
+    class change_flag
+    {
+    public:
+        typedef bool (*change_func_t)(bool);
+
+        /**
+            Constructor changes the flag using the specified function.
+
+            The same function will be called from this object destructor to
+            restore the flag value.
+
+            @param change_func one of xml::init static methods, such as
+                indent_output or remove_whitespace
+            @param flag the value of the flag to use
+         */
+        change_flag(change_func_t change_func, bool flag)
+            : change_func_(change_func),
+              flag_orig_((*change_func)(flag))
+        {
+        }
+
+        /// Destructor restores the original flag value.
+        ~change_flag()
+        {
+            (*change_func_)(flag_orig_);
+        }
+
+    private:
+        change_func_t const change_func_;
+        bool const flag_orig_;
+    };
+
+    /**
         This member function controls whether or not the XML parser should
         add text nodes for indenting when generating XML text output from a
         node tree. The default is true.

--- a/include/xmlwrapp/version.h
+++ b/include/xmlwrapp/version.h
@@ -41,7 +41,7 @@
 
 #define XMLWRAPP_VERSION_MAJOR   0
 #define XMLWRAPP_VERSION_MINOR   9
-#define XMLWRAPP_VERSION_MICRO   0
+#define XMLWRAPP_VERSION_MICRO   1
 
 /**
     Checks if xmlwrapp version is at least @a major.@a minor.@a micro.

--- a/src/libxml/init.cxx
+++ b/src/libxml/init.cxx
@@ -39,6 +39,18 @@
 #include <libxml/xmlerror.h>
 #include <libxml/parser.h>
 
+namespace
+{
+
+bool change_flag_and_return_old_value(int* flag, bool new_value)
+{
+    const bool old_value = *flag != 0;
+    *flag = new_value ? 1 : 0;
+    return old_value;
+}
+
+} // anonymous namespace
+
 namespace xml
 {
 
@@ -78,33 +90,33 @@ void init::shutdown_library()
 }
 
 
-void init::indent_output(bool flag)
+bool init::indent_output(bool flag)
 {
-    xmlIndentTreeOutput = flag ? 1 : 0;
+    return change_flag_and_return_old_value(&xmlIndentTreeOutput, flag);
 }
 
 
-void init::remove_whitespace(bool flag)
+bool init::remove_whitespace(bool flag)
 {
-    xmlKeepBlanksDefaultValue = flag ? 0 : 1;
+    return !change_flag_and_return_old_value(&xmlKeepBlanksDefaultValue, !flag);
 }
 
 
-void init::substitute_entities(bool flag)
+bool init::substitute_entities(bool flag)
 {
-    xmlSubstituteEntitiesDefaultValue = flag ? 1 : 0;
+    return change_flag_and_return_old_value(&xmlSubstituteEntitiesDefaultValue, flag);
 }
 
 
-void init::load_external_subsets(bool flag)
+bool init::load_external_subsets(bool flag)
 {
-    xmlLoadExtDtdDefaultValue = flag ? 1 : 0;
+    return change_flag_and_return_old_value(&xmlLoadExtDtdDefaultValue, flag);
 }
 
 
-void init::validate_xml(bool flag)
+bool init::validate_xml(bool flag)
 {
-    xmlDoValidityCheckingDefaultValue = flag ? 1 : 0;
+  return change_flag_and_return_old_value(&xmlDoValidityCheckingDefaultValue, flag);
 }
 
 } // namespace xml

--- a/tests/document/test_document.cxx
+++ b/tests/document/test_document.cxx
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_SUITE( document )
 
 BOOST_AUTO_TEST_CASE( dump_type )
 {
-    xml::init::substitute_entities(false);
+    xml::init::change_flag change(&xml::init::substitute_entities, false);
 
     xml::tree_parser parser(test_file_path("document/data/01.xml").c_str());
 

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -471,7 +471,7 @@ namespace
 
 void do_dump_node_types(const char *xmlfile, const char *outfile)
 {
-    xml::init::substitute_entities(false);
+    xml::init::change_flag change(&xml::init::substitute_entities, false);
 
     xml::tree_parser parser(test_file_path(xmlfile).c_str());
     xml::node &root = parser.get_document().get_root_node();
@@ -480,10 +480,6 @@ void do_dump_node_types(const char *xmlfile, const char *outfile)
     dump_node_type(ostr, root);
 
     BOOST_CHECK( is_same_as_file(ostr, outfile) );
-
-    // FIXME: don't rely on the default being 'true', read the current value
-    //        from xml::init
-    xml::init::substitute_entities(true);
 }
 
 }
@@ -502,7 +498,7 @@ BOOST_AUTO_TEST_CASE( dump_node_types )
 
 static void do_sort_by_attr(const char *xmlfile, const char *outfile)
 {
-    xml::init::remove_whitespace(true);
+    xml::init::change_flag change(&xml::init::remove_whitespace, true);
 
     xml::tree_parser parser(test_file_path(xmlfile).c_str());
 
@@ -510,10 +506,6 @@ static void do_sort_by_attr(const char *xmlfile, const char *outfile)
     root.sort("child", "order");
 
     BOOST_CHECK( is_same_as_file(parser.get_document(), outfile) );
-
-    // FIXME: don't rely on the default being 'false', read the current value
-    //        from xml::init
-    xml::init::remove_whitespace(false);
 }
 
 BOOST_AUTO_TEST_CASE( sort_by_attr )
@@ -544,7 +536,7 @@ struct node_sort_cmp : public std::binary_function<xml::node, xml::node, bool>
 
 BOOST_AUTO_TEST_CASE( sort_with_predicate )
 {
-    xml::init::remove_whitespace(true);
+    xml::init::change_flag change(&xml::init::remove_whitespace, true);
 
 
     xml::tree_parser parser(test_file_path("node/data/08a.xml").c_str());
@@ -553,10 +545,6 @@ BOOST_AUTO_TEST_CASE( sort_with_predicate )
     root.sort(node_sort_cmp());
 
     BOOST_CHECK( is_same_as_file(parser.get_document(), "node/data/08a.out") );
-
-    // FIXME: don't rely on the default being 'false', read the current value
-    //        from xml::init
-    xml::init::remove_whitespace(false);
 }
 
 


### PR DESCRIPTION
Do this in order to allow changing various globals (even though we're only really interested in `remove_whitespace()` flag, it seems to be better to consistently do it for all of them) temporarily.