### PR TITLE
Avoid redundant namespace definitions

### DIFF
--- a/tests/node/data/copy_ns.out
+++ b/tests/node/data/copy_ns.out
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<root xmlns="http://pmade.org/namespace/test">
+    <foo><child_with_same_ns/><child_with_diff_ns xmlns="http://pmade.org/namespace/different"/></foo>
+<bar><foo><child_with_same_ns/><child_with_diff_ns xmlns="http://pmade.org/namespace/different"/></foo></bar></root>

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -718,23 +718,32 @@ TEST_CASE_METHOD( SrcdirConfig, "node/compare_nodes_view_iterators", "[node]" )
     CHECK( !(ci != i2) );
 }
 
-
-TEST_CASE_METHOD( SrcdirConfig, "node/get_namespace", "[node]" )
+// Test fixture providing "doc" preloaded with the contents of namespace.xml.
+class NamespaceTest : private SrcdirConfig
 {
-    xml::tree_parser parser(test_file_path("node/data/namespace.xml").c_str());
+public:
+    NamespaceTest()
+        : parser(test_file_path("node/data/namespace.xml").c_str()),
+          doc(parser.get_document())
+    {
+    }
 
+protected:
+    xml::tree_parser parser;
+    xml::document doc;
+};
+
+TEST_CASE_METHOD( NamespaceTest, "node/get_namespace", "[node][ns]" )
+{
     CHECK_THAT
     (
-        parser.get_document().get_root_node().get_namespace(),
+        doc.get_root_node().get_namespace(),
         Catch::Matchers::Equals("http://pmade.org/namespace/test")
     );
 }
 
-TEST_CASE_METHOD( SrcdirConfig, "node/set_namespace", "[node]" )
+TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
 {
-    xml::tree_parser parser(test_file_path("node/data/namespace.xml").c_str());
-    xml::document doc(parser.get_document());
-
     doc.get_root_node().set_namespace("http://pmade.org/namespace/newOne");
 
     CHECK( is_same_as_file(doc, "node/data/namespace.out") );

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -748,3 +748,23 @@ TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
 
     CHECK( is_same_as_file(doc, "node/data/namespace.out") );
 }
+
+TEST_CASE_METHOD( NamespaceTest, "node/copy_ns", "[node][ns]" )
+{
+    xml::node& root = doc.get_root_node();
+    xml::node::iterator foo = root.find("foo");
+    REQUIRE( foo != root.end() );
+
+    xml::node child_with_same_ns("child_with_same_ns");
+    child_with_same_ns.set_namespace("http://pmade.org/namespace/test");
+    foo->insert(child_with_same_ns);
+
+    xml::node child_with_diff_ns("child_with_diff_ns");
+    child_with_diff_ns.set_namespace("http://pmade.org/namespace/different");
+    foo->insert(child_with_diff_ns);
+
+    xml::node::iterator bar = root.insert(xml::node("bar"));
+    bar->insert(*foo);
+
+    CHECK( is_same_as_file(doc, "node/data/copy_ns.out") );
+}

--- a/tests/test.h
+++ b/tests/test.h
@@ -73,7 +73,11 @@ inline std::string read_file_into_string(std::istream& stream)
 
 inline std::string read_file_into_string(const std::string& filename)
 {
-    std::ifstream f(test_file_path(filename).c_str());
+    const std::string& path = test_file_path(filename);
+    std::ifstream f(path.c_str());
+    INFO("file \"" << path << "\" couldn't be opened");
+    REQUIRE( f.good() );
+
     return read_file_into_string(f);
 }
 


### PR DESCRIPTION
I _hope_ I've finally got it right (it took me a long time to understand just how exactly libxml2 handled namespaces) with this change, which eliminates the artificial namespace definition created by `xmlCopyNode()`.

The only thing I'm not sure about is whether there is no simpler way to achieve the same thing, but I couldn't find anything like this in libxml2 API (notably `xmlCopyDocNode()` isn't better).

To see the difference in behaviour: before the change to `node_manip.cxx` the unit test would fail because the output contained `<bar><foo xmlns="http://pmade.org/namespace/test"/></bar>` instead of just the expected `<bar><foo/></bar>`.