### PR TITLE
Enable more useful gcc warnings not part of -Wall by default

### DIFF
--- a/admin/ax_append_compile_flags.m4
+++ b/admin/ax_append_compile_flags.m4
@@ -1,0 +1,46 @@
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3], [$4])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/admin/ax_append_flag.m4
+++ b/admin/ax_append_flag.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/admin/ax_check_compile_flag.m4
+++ b/admin/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/admin/ax_require_defined.m4
+++ b/admin/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,34 @@ AC_HEADER_ASSERT
 
 dnl === Compiler-specific stuff ===
 
+AC_CACHE_CHECK([if using clang],
+    xmlwrapp_cv_prog_clang,
+    [
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                [],
+                [[
+                #ifndef __clang__
+                    not clang
+                #endif
+                ]],
+            )],
+            xmlwrapp_cv_prog_clang=yes,
+            xmlwrapp_cv_prog_clang=no
+        )
+    ]
+)
+
+CLANG=$xmlwrapp_cv_prog_clang
+
+dnl Enable more warnings for the compilers we know about.
+if test "x$CLANG" == "xyes"; then
+    dnl Enable clang-specific warnings.
+    CXXFLAGS="$CXXFLAGS -Wextra-semi"
+elif test "x$GCC" == "xyes"; then
+    dnl Enable gcc-only warnings here.
+    :
+fi
+
 if test "x$GCC" == "xyes"; then
     dnl Enable some useful warnings that GCC supports:
     CXXFLAGS="$CXXFLAGS -W -Wall -Wcast-align -Wcast-qual -Wconversion -Wsign-conversion -Wwrite-strings"

--- a/configure.ac
+++ b/configure.ac
@@ -149,12 +149,18 @@ if test "x$CLANG" == "xyes"; then
     CXXFLAGS="$CXXFLAGS -Wextra-semi"
 elif test "x$GCC" == "xyes"; then
     dnl Enable gcc-only warnings here.
-    :
+    CXXFLAGS="$CXXFLAGS -Wlogical-op -Wuseless-cast"
+
+    dnl These warnings are not supported by the old gcc versions.
+    AX_APPEND_COMPILE_FLAGS([-Wduplicated-cond -Wnull-dereference])
 fi
 
 if test "x$GCC" == "xyes"; then
-    dnl Enable some useful warnings that GCC supports:
-    CXXFLAGS="$CXXFLAGS -W -Wall -Wcast-align -Wcast-qual -Wconversion -Wsign-conversion -Wwrite-strings"
+    dnl Enable some useful warnings that both clang and gcc support that are
+    dnl not already enabled by -Wall
+    CXXFLAGS="$CXXFLAGS -W -Wall -Wcast-align -Wcast-qual -Wconversion\
+ -Wdouble-promotion -Woverloaded-virtual -Wsign-conversion -Wshadow\
+ -Wtype-limits -Wswitch-enum -Wundef -Wwrite-strings"
 fi
 
 dnl Check if the compiler supports symbols visibility:

--- a/include/xmlwrapp/document.h
+++ b/include/xmlwrapp/document.h
@@ -136,12 +136,12 @@ public:
         constructor will throw xml::exception anyway.
 
         @param data The XML data to parse.
-        @param size The size of the XML data to parse.
+        @param len The length of the XML data to parse.
         @param on_error Handler called to process errors and warnings.
 
         @since 0.7.0
      */
-    explicit document(const char *data, size_type size, error_handler& on_error = throw_on_error);
+    explicit document(const char *data, size_type len, error_handler& on_error = throw_on_error);
 
     /**
         Copy construct a new XML document. The new document will be an exact

--- a/include/xmlwrapp/errors.h
+++ b/include/xmlwrapp/errors.h
@@ -157,11 +157,11 @@ public:
     /**
         Create a new xml::error_message object.
 
-        @param message  The error message.
+        @param err_msg  The error message.
         @param msg_type The error type.
      */
-    error_message(const std::string& message, message_type msg_type)
-        : message_(message), type_(msg_type)
+    error_message(const std::string& err_msg, message_type msg_type)
+        : message_(err_msg), type_(msg_type)
     {}
 
     /// Get the error message type.

--- a/src/libxml/document.cxx
+++ b/src/libxml/document.cxx
@@ -203,10 +203,10 @@ document::document(const char *filename, error_handler& on_error)
     swap(p.get_document());
 }
 
-document::document(const char *data, size_type size, error_handler& on_error)
+document::document(const char *data, size_type len, error_handler& on_error)
 {
     pimpl_ = NULL;
-    tree_parser p(data, size, on_error);
+    tree_parser p(data, len, on_error);
     if ( !p )
         throw exception(p.messages());
     swap(p.get_document());

--- a/src/libxml/errors.cxx
+++ b/src/libxml/errors.cxx
@@ -47,11 +47,11 @@ error_handler_throw_on_error_or_warning  throw_on_error_or_warning;
 // xml::exception
 // ------------------------------------------------------------------------
 
-exception::exception(const std::string& what) : std::runtime_error(what)
+exception::exception(const std::string& what_) : std::runtime_error(what_)
 {
 }
 
-exception::exception(const error_messages& what) : std::runtime_error(what.print())
+exception::exception(const error_messages& what_) : std::runtime_error(what_.print())
 {
 }
 

--- a/src/libxml/node_iterator.cxx
+++ b/src/libxml/node_iterator.cxx
@@ -59,7 +59,7 @@ struct impl::nipimpl
 {
     node_iterator it;
 
-    nipimpl() {};
+    nipimpl() {}
     nipimpl(xmlNodePtr ptr) : it(ptr) {}
     nipimpl(const nipimpl& other) : it(other.it) {}
 };


### PR DESCRIPTION
In combination with the use of -Werror for the CI builds, this will
catch any warnings introduced in the new code, while not being too
bothersome for people compiling the library without -Werror, i.e. most
of the normal users.