### PR TITLE
Add a build using g++ 8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ matrix:
   - compiler: gcc
   - compiler: gcc
     env: CXXFLAGS="-std=c++11"
+  - addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-8
+    env: SET_CXX="CC=gcc-8 CXX=g++-8"
   - compiler: clang
   - compiler: clang
     env: CXXFLAGS="-std=c++11"

--- a/scripts/travis/common.sh
+++ b/scripts/travis/common.sh
@@ -7,3 +7,9 @@ if [ -n "$HOST" ]; then
     unset CC
     unset CXX
 fi
+
+# When using non-default compiler, .travis.yml defines SET_CXX to contain CXX
+# (and CC) definitions.
+if [ -n "$SET_CXX" ]; then
+    eval "$SET_CXX"
+fi


### PR DESCRIPTION
Try using newer compiler in addition to the ancient 4.8 used by default.