### PR TITLE
Support building Win32 DLLs without relying on auto-import

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ dnl deterministic archives (that can't include the timestamps) when building
 dnl all static libraries with default "cru" flags used by Libtool up to 2.4.6.
 AR_FLAGS=cr
 
-AC_PROG_LIBTOOL
+LT_INIT([win32-dll])
 
 
 dnl === Library checks ===

--- a/docs/manual/prepare.doxygen
+++ b/docs/manual/prepare.doxygen
@@ -22,6 +22,18 @@ file you need or use the master include file to include all
 xmlwrapp header files. The choice is yours and mainly depends on
 your style and the project you are working on.
 
+@subsection using_win32_dll Using DLLs under Microsoft Windows systems
+
+If xmlwrapp was built as a DLL, you must predefine @c XMLWRAPP_USE_DLL before
+including any of the library headers, e.g. typically in the project build
+options. Similarly, @c XSLTWRAPP_USE_DLL must be defined when using xsltwrapp
+as a DLL.
+
+Note that this it is not necessary to do this when using GNU toolset, as GNU
+linker can automatically import symbols from the DLLs as needed. However this
+is required when using other toolsets, such as Microsoft C++ one, and may be
+slightly more efficient than relying on auto-linking even with GNU linker.
+
 @subsection prepare_headers_example1 Include xmlwrapp Header Files
 
 @code

--- a/include/xmlwrapp/attributes.h
+++ b/include/xmlwrapp/attributes.h
@@ -110,7 +110,7 @@ public:
         The xml::attributes::attr class is used to hold information about one
         attribute.
      */
-    class attr
+    class XMLWRAPP_API attr
     {
     public:
         /**
@@ -147,7 +147,7 @@ public:
     /**
         Iterator class for accessing attribute pairs.
      */
-    class iterator
+    class XMLWRAPP_API iterator
     {
     public:
         typedef attr value_type;
@@ -188,7 +188,7 @@ public:
     /**
         Const Iterator class for accessing attribute pairs.
      */
-    class const_iterator
+    class XMLWRAPP_API const_iterator
     {
     public:
         typedef const attr value_type;

--- a/include/xmlwrapp/export.h
+++ b/include/xmlwrapp/export.h
@@ -33,11 +33,37 @@
 #ifndef _xmlwrapp_export_h_
 #define _xmlwrapp_export_h_
 
-#ifdef HAVE_VISIBILITY
+#if defined(_WIN32)
+    // Note that DLL_EXPORT is predefined by libtool when building the DLLs,
+    // but when using them, XMLWRAPP_USE_DLL or XSLTWRAPP_USE_DLL must be
+    // predefined by the application.
+    #if defined(DLL_EXPORT)
+        #if defined(XMLWRAPP_BUILD)
+            #define XMLWRAPP_API __declspec(dllexport)
+        #endif
+
+        #if defined(XSLTWRAPP_BUILD)
+            #define XSLTWRAPP_API __declspec(dllexport)
+        #endif
+    #endif
+
+    #if defined(XMLWRAPP_USE_DLL)
+        #define XMLWRAPP_API __declspec(dllimport)
+    #endif
+
+    #if defined(XSLTWRAPP_USE_DLL)
+        #define XSLTWRAPP_API __declspec(dllimport)
+    #endif
+#elif defined(HAVE_VISIBILITY)
     #define XMLWRAPP_API   __attribute__ ((visibility("default")))
     #define XSLTWRAPP_API  __attribute__ ((visibility("default")))
-#else
+#endif
+
+#ifndef XMLWRAPP_API
     #define XMLWRAPP_API
+#endif
+
+#ifndef XSLTWRAPP_API
     #define XSLTWRAPP_API
 #endif
 

--- a/include/xmlwrapp/export.h
+++ b/include/xmlwrapp/export.h
@@ -58,9 +58,9 @@
         #define XMLWRAPP_DEPRECATED(msg) __declspec(deprecated("deprecated: " msg))
     #elif _MSC_VER >= 1300
         #define XMLWRAPP_DEPRECATED(msg) __declspec(deprecated)
-	#else
-		#define XMLWRAPP_DEPRECATED(msg)
-	#endif
+    #else
+        #define XMLWRAPP_DEPRECATED(msg)
+    #endif
 #else
     #define XMLWRAPP_DEPRECATED(msg)
 #endif

--- a/include/xmlwrapp/node.h
+++ b/include/xmlwrapp/node.h
@@ -431,7 +431,7 @@ public:
 
         Note that this is only a forward iterator.
      */
-    class iterator
+    class XMLWRAPP_API iterator
     {
     public:
         typedef node value_type;
@@ -474,7 +474,7 @@ public:
 
         Note that this is only a forward iterator.
      */
-    class const_iterator
+    class XMLWRAPP_API const_iterator
     {
     public:
         typedef const node value_type;

--- a/include/xmlwrapp/nodes_view.h
+++ b/include/xmlwrapp/nodes_view.h
@@ -95,7 +95,7 @@ public:
 
         As xml::node::iterator itself, this is only a forward iterator.
      */
-    class iterator
+    class XMLWRAPP_API iterator
     {
     public:
         typedef node value_type;
@@ -138,7 +138,7 @@ public:
 
         As xml::node::const_iterator itself, this is only a forward iterator.
      */
-    class const_iterator
+    class XMLWRAPP_API const_iterator
     {
     public:
         typedef const node value_type;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ else
 lib_LTLIBRARIES = libxmlwrapp.la
 endif
 
-libxmlwrapp_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBXML_CFLAGS)
+libxmlwrapp_la_CPPFLAGS = -DXMLWRAPP_BUILD $(AM_CPPFLAGS) $(LIBXML_CFLAGS)
 libxmlwrapp_la_LIBADD = $(LIBXML_LIBS)
 libxmlwrapp_la_LDFLAGS = -version-info 6:0:0 -no-undefined
 
@@ -39,7 +39,7 @@ libxmlwrapp_la_SOURCES = \
 
 if WITH_XSLT
 
-libxsltwrapp_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBEXSLT_CFLAGS) $(LIBXSLT_CFLAGS)
+libxsltwrapp_la_CPPFLAGS = -DXSLTWRAPP_BUILD -DXMLWRAPP_USE_DLL $(AM_CPPFLAGS) $(LIBEXSLT_CFLAGS) $(LIBXSLT_CFLAGS)
 libxsltwrapp_la_LIBADD = libxmlwrapp.la $(LIBEXSLT_LIBS) $(LIBXSLT_LIBS)
 libxsltwrapp_la_LDFLAGS = -version-info 4:0:0 -no-undefined
 


### PR DESCRIPTION
I was a bit surprised that the library didn't already support this, especially considering that it did have `export.h`, so I've added support for this. To be honest, I'm not exactly sure how is this supposed to be handled with libtool and its weird idea of building any subset of static/shared libraries, but I think this should work and it seems to do it in my tests.