### PR TITLE
Add build using ASAN to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
             cxxflags: -std=c++11
           - name: Ubuntu 20.04
             runner: ubuntu-20.04
+          - name: Ubuntu 20.04 ASAN
+            runner: ubuntu-20.04
+            cxxflags: -fsanitize=address -fno-omit-frame-pointer
+            ldflags: -fsanitize=address
           - name: Ubuntu 20.04 clang
             runner: ubuntu-20.04
             compiler: clang++
@@ -44,6 +48,7 @@ jobs:
       HOST: ${{ matrix.host }}
       CXX: ${{ matrix.compiler || 'g++' }}
       CXXFLAGS: ${{ matrix.cxxflags }}
+      LDFLAGS: ${{ matrix.ldflags }}
       TEST_DIST: ${{ matrix.test_dist }}
 
     steps:

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -24,7 +24,7 @@ case "$HOST" in
         ;;
 esac
 
-./configure CXXFLAGS="$CXXFLAGS" $configure_args
+./configure CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" $configure_args
 
 # Test building from a distribution archive, rather than from Git sources.
 if [ "$TEST_DIST" = 1 ]; then


### PR DESCRIPTION
This requires passing LDFLAGS to configure too, in addition to CXXFLAGS.