### PR TITLE
Ensure that children namespaces are updated after set_namespace()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 0.9.2
+
+    New behaviour: xml::node::set_namespace() now sets the namespace for all
+    node children when the node hadn't had any namespace before too, instead
+    of only doing it when the node namespace is being changed.
+
 Version 0.9.1
 
     Added return value for xml::init methods setting various boolean flags:

--- a/include/xmlwrapp/node.h
+++ b/include/xmlwrapp/node.h
@@ -365,7 +365,16 @@ public:
     const char* get_namespace() const;
 
     /**
-        Set the default namespace of this xml::node.
+        Set the namespace of this xml::node and its children.
+
+        Calling this function also affects the namespace of the children of
+        this node, if any: all children that previously used the same namespace
+        as this node are updated to use the new namespace. This includes the
+        case when this node didn't previously have any namespace, but note that
+        in this particular case, when a new namespace is being set, this
+        function needs to update all children and so can be relatively
+        time-consuming for large trees, while changing an existing namespace is
+        done in constant time.
 
         If the default namespace is already set on this node, it is changed.
 

--- a/src/libxml/node.cxx
+++ b/src/libxml/node.cxx
@@ -613,7 +613,16 @@ void node::set_namespace(const std::string& href)
             throw xml::exception("set_namespace failed to create namespace object");
     }
 
-    xmlSetNs(pimpl_->xmlnode_, ns);
+    // If we already have a namespace, all our children without their own
+    // namespaces should already use the same pointer, so their namespaces will
+    // be updated when our namespace is changed. However if we don't have any
+    // namespace yet, children namespaces will remain unset, which would break
+    // the expected namespace inheritance and so we need to set them explicitly
+    // to avoid this.
+    if ( pimpl_->xmlnode_->ns )
+        xmlSetNs(pimpl_->xmlnode_, ns);
+    else
+        node_set_ns_recursively(pimpl_->xmlnode_, ns);
 }
 
 

--- a/src/libxml/node_manip.cxx
+++ b/src/libxml/node_manip.cxx
@@ -80,7 +80,7 @@ void replace_ns_recursively(xmlNodePtr node, xmlNsPtr old_ns, xmlNsPtr new_ns)
         return;
     }
 
-    node->ns = new_ns;
+    xmlSetNs(node, new_ns);
 
     for ( xmlNodePtr child = node->children; child; child = child->next )
         replace_ns_recursively(child, old_ns, new_ns);

--- a/src/libxml/node_manip.cxx
+++ b/src/libxml/node_manip.cxx
@@ -207,3 +207,8 @@ xmlNodePtr xml::impl::node_erase(xmlNodePtr to_erase)
 
     return after;
 }
+
+void xml::impl::node_set_ns_recursively(xmlNodePtr node, xmlNsPtr ns)
+{
+    replace_ns_recursively(node, NULL, ns);
+}

--- a/src/libxml/node_manip.h
+++ b/src/libxml/node_manip.h
@@ -88,6 +88,13 @@ xmlNodePtr node_replace(xmlNodePtr old_node, xmlNodePtr new_node);
  */
 xmlNodePtr node_erase(xmlNodePtr to_erase);
 
+/**
+    @internal
+
+    Set namespace for this node and all its children not using any namespace.
+ */
+void node_set_ns_recursively(xmlNodePtr node, xmlNsPtr ns);
+
 } // namespace impl
 
 } // namespace xml

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -724,37 +724,38 @@ class NamespaceTest : private SrcdirConfig
 public:
     NamespaceTest()
         : parser(test_file_path("node/data/namespace.xml").c_str()),
-          doc(parser.get_document())
+          doc(parser.get_document()),
+          root(doc.get_root_node()),
+          foo(root.find("foo"))
     {
+        REQUIRE( foo != root.end() );
     }
 
 protected:
     xml::tree_parser parser;
     xml::document doc;
+    xml::node& root;
+    xml::node::iterator foo;
 };
 
 TEST_CASE_METHOD( NamespaceTest, "node/get_namespace", "[node][ns]" )
 {
     CHECK_THAT
     (
-        doc.get_root_node().get_namespace(),
+        root.get_namespace(),
         Catch::Matchers::Equals("http://pmade.org/namespace/test")
     );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
 {
-    doc.get_root_node().set_namespace("http://pmade.org/namespace/newOne");
+    root.set_namespace("http://pmade.org/namespace/newOne");
 
     CHECK( is_same_as_file(doc, "node/data/namespace.out") );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/copy_ns", "[node][ns]" )
 {
-    xml::node& root = doc.get_root_node();
-    xml::node::iterator foo = root.find("foo");
-    REQUIRE( foo != root.end() );
-
     xml::node child_with_same_ns("child_with_same_ns");
     child_with_same_ns.set_namespace("http://pmade.org/namespace/test");
     foo->insert(child_with_same_ns);

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -738,19 +738,20 @@ protected:
     xml::node::iterator foo;
 };
 
+// Helper macro for checking that the given namespace is equal to the correct
+// value. It is used because get_namespace() may return NULL, and so can't be
+// just compared with the expected string because comparison function would
+// crash if it were used with a NULL pointer and it is a macro rather than a
+// function to point to the correct line number in case of failure.
+#define XMLWRAPP_CHECK_NS(ns, expected)         \
+    CHECK( ns );                                \
+    if ( ns )                                   \
+        CHECK( std::string(ns) == expected )
+
 TEST_CASE_METHOD( NamespaceTest, "node/get_namespace", "[node][ns]" )
 {
-    CHECK_THAT
-    (
-        root.get_namespace(),
-        Catch::Matchers::Equals("http://pmade.org/namespace/test")
-    );
-
-    CHECK_THAT
-    (
-        foo->get_namespace(),
-        Catch::Matchers::Equals("http://pmade.org/namespace/test")
-    );
+    XMLWRAPP_CHECK_NS( root.get_namespace(), "http://pmade.org/namespace/test" );
+    XMLWRAPP_CHECK_NS( foo->get_namespace(), "http://pmade.org/namespace/test" );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
@@ -759,11 +760,7 @@ TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
 
     CHECK( is_same_as_file(doc, "node/data/namespace.out") );
 
-    CHECK_THAT
-    (
-        foo->get_namespace(),
-        Catch::Matchers::Equals("http://pmade.org/namespace/newOne")
-    );
+    XMLWRAPP_CHECK_NS( foo->get_namespace(), "http://pmade.org/namespace/newOne" );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/copy_ns", "[node][ns]" )

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -745,6 +745,12 @@ TEST_CASE_METHOD( NamespaceTest, "node/get_namespace", "[node][ns]" )
         root.get_namespace(),
         Catch::Matchers::Equals("http://pmade.org/namespace/test")
     );
+
+    CHECK_THAT
+    (
+        foo->get_namespace(),
+        Catch::Matchers::Equals("http://pmade.org/namespace/test")
+    );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
@@ -752,6 +758,12 @@ TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
     root.set_namespace("http://pmade.org/namespace/newOne");
 
     CHECK( is_same_as_file(doc, "node/data/namespace.out") );
+
+    CHECK_THAT
+    (
+        foo->get_namespace(),
+        Catch::Matchers::Equals("http://pmade.org/namespace/newOne")
+    );
 }
 
 TEST_CASE_METHOD( NamespaceTest, "node/copy_ns", "[node][ns]" )

--- a/tests/node/test_node.cxx
+++ b/tests/node/test_node.cxx
@@ -763,6 +763,41 @@ TEST_CASE_METHOD( NamespaceTest, "node/set_namespace", "[node][ns]" )
     XMLWRAPP_CHECK_NS( foo->get_namespace(), "http://pmade.org/namespace/newOne" );
 }
 
+TEST_CASE( "node/set_namespace_new", "[node][ns]" )
+{
+    xml::node root("root");
+    xml::node child("child");
+    child.push_back(xml::node("grandchild"));
+    root.push_back(child);
+
+    const std::string nsChild("http://pmade.org/namespace/childNS");
+    xml::node child_with_ns("child_with_ns");
+    child_with_ns.set_namespace(nsChild);
+    child_with_ns.push_back(xml::node("grandchild"));
+    root.push_back(child_with_ns);
+
+    const std::string nsNew("http://pmade.org/namespace/newOne");
+    root.set_namespace(nsNew);
+
+    XMLWRAPP_CHECK_NS( root.get_namespace(), nsNew );
+
+    xml::node::const_iterator it = root.find("child");
+    REQUIRE( it != root.end() );
+    XMLWRAPP_CHECK_NS( it->get_namespace(), nsNew );
+
+    xml::node::const_iterator it2 = it->find("grandchild");
+    REQUIRE( it2 != it->end() );
+    XMLWRAPP_CHECK_NS( it2->get_namespace(), nsNew );
+
+    it = root.find("child_with_ns");
+    REQUIRE( it != root.end() );
+    XMLWRAPP_CHECK_NS( it->get_namespace(), nsChild );
+
+    it2 = it->find("grandchild");
+    REQUIRE( it2 != it->end() );
+    XMLWRAPP_CHECK_NS( it2->get_namespace(), nsChild );
+}
+
 TEST_CASE_METHOD( NamespaceTest, "node/copy_ns", "[node][ns]" )
 {
     xml::node child_with_same_ns("child_with_same_ns");


### PR DESCRIPTION
This is yet another namespace-related tweak/fix. I initially wanted to add `set_namespace_recursively()`, but finally decided that it made more sense to change `set_namespace()` itself because there is no possible reason for it to update the children namespace when changing the parent namespace, but not when setting it, as it does now.

Please let me know if you disagree.