### PR TITLE
Set ELF visibility of xml::exception to public

### DIFF
--- a/include/xmlwrapp/errors.h
+++ b/include/xmlwrapp/errors.h
@@ -65,10 +65,10 @@ class error_messages;
 class XMLWRAPP_INLINE_API exception : public std::runtime_error
 {
 public:
-    explicit exception(const std::string& what)
-        : std::runtime_error(what)
+    explicit exception(const std::string& what_arg)
+        : std::runtime_error(what_arg)
     {}
-    explicit exception(const error_messages& what);
+    explicit exception(const error_messages& what_arg);
 };
 
 
@@ -245,8 +245,8 @@ private:
 };
 
 
-inline exception::exception(const error_messages& what)
-    : std::runtime_error(what.print())
+inline exception::exception(const error_messages& what_arg)
+    : std::runtime_error(what_arg.print())
 {
 }
 

--- a/include/xmlwrapp/errors.h
+++ b/include/xmlwrapp/errors.h
@@ -62,7 +62,7 @@ class error_messages;
 
     @since 0.7.0
  */
-class exception : public std::runtime_error
+class XMLWRAPP_INLINE_API exception : public std::runtime_error
 {
 public:
     explicit exception(const std::string& what)

--- a/include/xmlwrapp/export.h
+++ b/include/xmlwrapp/export.h
@@ -67,6 +67,21 @@
     #define XSLTWRAPP_API
 #endif
 
+// Special case of classes having only inline functions: they don't need to be
+// DLL-exported when using MSVS and, if they derive from any standard classes,
+// exporting them just results in annoying warnings, but they do have to have
+// public visibility when using clang/libc++ under macOS as otherwise their
+// type info would be different in the application and the library, resulting
+// in fatal problems, such as inability to catch the exceptions thrown by the
+// library.
+//
+// So define a special macro which must be used for such classes only.
+#if defined(_WIN32)
+    #define XMLWRAPP_INLINE_API
+#else
+    #define XMLWRAPP_INLINE_API XMLWRAPP_API
+#endif
+
 #if defined(__clang__)
     #if defined(__has_extension) && __has_extension(attribute_deprecated_with_message)
         #define XMLWRAPP_DEPRECATED(msg) __attribute__((deprecated(msg)))


### PR DESCRIPTION
This is important for clang under macOS, as otherwise exceptions of this type are not caught properly in the applications using xmlwrapp.

---

I admit that I don't fully understand the mechanism here, but I _think_ that not giving the class public visibility results in allocating its typeinfo both in the shared library and in the application and because clang/libc++ (stupidly, IMO) compare typeinfos by address and not by value (as gcc/libstdc++ does since many years exactly in order to avoid such problems), this results in failure to catch exceptions thrown from the library using `catch(const xml::exception&)` in the application -- and, due to this, in many tests failures.