### PR TITLE
Fix replacing nodes with libxml 2.10 and later

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ Version 0.10.0 [not released yet]
     Improve error reporting again by including more details. This changes the
     error messages format compared to the previous versions.
 
+    Fix replacing nodes with libxml 2.10 and later (#87).
+
 Version 0.9.1 [2020-11-01]
 
     Added return value for xml::init methods setting various boolean flags:

--- a/src/libxml/node_manip.cxx
+++ b/src/libxml/node_manip.cxx
@@ -180,11 +180,14 @@ xml::impl::node_replace(xmlNodePtr old_node, xmlNodePtr new_node)
 {
     xmlNodePtr const copied_node = copy_node_under_parent(old_node->parent, new_node);
 
-    // hack to see if xmlReplaceNode was successful
-    copied_node->doc = reinterpret_cast<xmlDocPtr>(old_node);
+    // hack to see if xmlReplaceNode was successful: it only updates doc
+    // pointer of the new node if everything went well, so check that it will
+    // change
+    xmlDoc dummyDoc{};
+    copied_node->doc = &dummyDoc;
     xmlReplaceNode(old_node, copied_node);
 
-    if ( copied_node->doc == reinterpret_cast<xmlDocPtr>(old_node) )
+    if ( copied_node->doc == &dummyDoc )
     {
         xmlFreeNode(copied_node);
         throw xml::exception("failed to replace xml::node; xmlReplaceNode() failed");


### PR DESCRIPTION
Don't use invalid xmlDocPtr, it is actually used by libxml2 now inside xmlReplaceNode(), so it must point to an actual xmlDoc -- even if just a dummy one.

See #87.